### PR TITLE
fix: #58 iPadでギャラリーのカラムレイアウトが崩れる問題を修正

### DIFF
--- a/src/components/organisms/PhotoGrid.astro
+++ b/src/components/organisms/PhotoGrid.astro
@@ -21,12 +21,12 @@ function resolveImage(src: string): ImageMetadata | undefined {
 ---
 
 <section class="p-4 sm:p-6">
-  <div class="columns-2 sm:columns-3 lg:columns-4 gap-3 space-y-3">
+  <div class="columns-2 sm:columns-3 md:columns-3 lg:columns-4 gap-3">
     {images.map((img, i) => {
       const imageSrc = resolveImage(img.data.src);
       return imageSrc && (
         <div
-          class="break-inside-avoid overflow-hidden rounded-2xl photo-item skeleton skeleton-img"
+          class="break-inside-avoid overflow-hidden rounded-2xl mb-3 photo-item skeleton skeleton-img"
           style={`box-shadow: 0 1px 4px var(--color-shadow-sm); animation-delay: ${i * 60}ms;`}
         >
           <Image


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yosse95ai :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## 変更内容

iPad（768px〜1024px）でギャラリーページのカラムレイアウトが崩れる問題を修正しました。

### 原因

CSS multi-column layout で `space-y-3`（`margin-top`）を使用すると、WebKit/Safari で子要素のレイアウトが正しく計算されず、カラムの配置が乱れる。

### 修正内容

- `space-y-3` をコンテナから削除
- 各 `.photo-item` に `mb-3` を追加（`margin-bottom` は columns レイアウトで正常に動作する）
- `md:columns-3` を追加して iPad 幅でのカラム数を明示的に保証

### テスト

- `astro build` 成功
- `vitest --run` 全60テスト通過

Closes #58