### PR TITLE
fix: #41 ホームページ デザイン改善

### DIFF
--- a/src/components/organisms/BlogList.astro
+++ b/src/components/organisms/BlogList.astro
@@ -1,6 +1,5 @@
 ---
 import OgpCard from '../molecules/OgpCard.astro';
-import SeeAllButton from '../molecules/SeeAllButton.astro';
 import { getCollection } from 'astro:content';
 import { fetchOgp } from '../../lib/fetchOgp';
 
@@ -30,7 +29,6 @@ const [awsCards, otherCards] = await Promise.all([
         externalUrl: a.data.externalUrl,
         type: 'aws' as const,
         ...ogp,
-        // JSONに publishedAt があればそれを優先
         publishedAt: a.data.publishedAt ?? ogp.publishedAt,
       };
     })
@@ -49,20 +47,15 @@ const [awsCards, otherCards] = await Promise.all([
   ),
 ]);
 
-// publishedAt 降順（null は末尾）
-const sortByDate = <T extends { publishedAt: string | null }>(cards: T[]) =>
-  cards.sort((a, b) => {
-    if (!a.publishedAt && !b.publishedAt) return 0;
-    if (!a.publishedAt) return 1;
-    if (!b.publishedAt) return -1;
-    return b.publishedAt.localeCompare(a.publishedAt);
-  });
+// 全記事をマージし publishedAt 降順（null は末尾）
+const allCards = [...awsCards, ...otherCards].sort((a, b) => {
+  if (!a.publishedAt && !b.publishedAt) return 0;
+  if (!a.publishedAt) return 1;
+  if (!b.publishedAt) return -1;
+  return b.publishedAt.localeCompare(a.publishedAt);
+});
 
-const sortedAwsCards = sortByDate(awsCards);
-const sortedOtherCards = sortByDate(otherCards);
-
-const displayedAwsCards   = limit !== undefined ? sortedAwsCards.slice(0, limit)   : sortedAwsCards;
-const displayedOtherCards = limit !== undefined ? sortedOtherCards.slice(0, limit) : sortedOtherCards;
+const displayedCards = limit !== undefined ? allCards.slice(0, limit) : allCards;
 ---
 
 <section
@@ -72,52 +65,30 @@ const displayedOtherCards = limit !== undefined ? sortedOtherCards.slice(0, limi
     Blog
   </h2>
 
-  <!-- AWS Blog -->
-  <div class="flex flex-col gap-3">
-    <p class="text-sm md:text-base font-mono text-text-muted">AWS Blog</p>
-    <div
-      class={layout === 'grid'
-        ? 'flex gap-4 overflow-x-auto pb-2 -mx-2 px-2 md:!grid md:overflow-x-visible md:pb-0 md:mx-0 md:px-0 md:grid-cols-4'
-        : 'flex gap-4 overflow-x-auto pb-2 -mx-2 px-2'}
-      style="scrollbar-width: thin; scrollbar-color: var(--color-border) transparent;"
-    >
-      {displayedAwsCards.map(card => (
-        <div class={layout === 'grid' ? 'shrink-0 w-72 md:shrink md:w-auto' : 'shrink-0 w-72'}>
-          <OgpCard
-            externalUrl={card.externalUrl}
-            title={card.title}
-            description={card.description}
-            ogpImage={card.ogpImage}
-          />
-        </div>
-      ))}
-      {limit !== undefined && layout !== 'grid' && <SeeAllButton href="/history#blog" />}
-    </div>
-  </div>
-
-  <!-- 区切り線 -->
-  <hr class="border-border" />
-
-  <!-- Other Blog -->
-  <div class="flex flex-col gap-3">
-    <p class="text-sm md:text-base font-mono text-text-muted">Other</p>
-    <div
-      class={layout === 'grid'
-        ? 'flex gap-4 overflow-x-auto pb-2 -mx-2 px-2 md:!grid md:overflow-x-visible md:pb-0 md:mx-0 md:px-0 md:grid-cols-4'
-        : 'flex gap-4 overflow-x-auto pb-2 -mx-2 px-2'}
-      style="scrollbar-width: thin; scrollbar-color: var(--color-border) transparent;"
-    >
-      {displayedOtherCards.map(card => (
-        <div class={layout === 'grid' ? 'shrink-0 w-72 md:shrink md:w-auto' : 'shrink-0 w-72'}>
-          <OgpCard
-            externalUrl={card.externalUrl}
-            title={card.title}
-            description={card.description}
-            ogpImage={card.ogpImage}
-          />
-        </div>
-      ))}
-      {limit !== undefined && layout !== 'grid' && <SeeAllButton href="/history#blog" />}
-    </div>
+  <div
+    class={layout === 'grid'
+      ? 'flex gap-4 overflow-x-auto pb-2 -mx-2 px-2 md:!grid md:overflow-x-visible md:pb-0 md:mx-0 md:px-0 md:grid-cols-4'
+      : 'flex gap-4 overflow-x-auto pb-2 -mx-2 px-2'}
+    style="scrollbar-width: thin; scrollbar-color: var(--color-border) transparent;"
+  >
+    {displayedCards.map(card => (
+      <div class={layout === 'grid' ? 'shrink-0 w-72 md:shrink md:w-auto' : 'shrink-0 w-72'}>
+        <OgpCard
+          externalUrl={card.externalUrl}
+          title={card.title}
+          description={card.description}
+          ogpImage={card.ogpImage}
+        />
+      </div>
+    ))}
+    {limit !== undefined && layout !== 'grid' && (
+      <a
+        href="/history#blog"
+        class="shrink-0 w-40 self-stretch rounded-2xl flex flex-col items-center justify-center gap-2 no-underline font-semibold text-sm md:text-base bg-primary text-primary-content border border-primary hover:opacity-80 transition-opacity"
+      >
+        <span class="text-lg">→</span>
+        <span class="text-sm md:text-base font-semibold">全てを見る</span>
+      </a>
+    )}
   </div>
 </section>

--- a/src/components/organisms/CareerTimeline.astro
+++ b/src/components/organisms/CareerTimeline.astro
@@ -33,7 +33,7 @@ function formatDate(ym: string): string {
   {showAll ? (
     <>
       {/* PC: CSS Grid レイアウト（md 以上） */}
-      <div class="hidden md:grid gap-y-0 relative" style="grid-template-columns: auto 1px 1fr;">
+      <div class="!hidden md:!grid gap-y-0 relative" style="grid-template-columns: auto 1px 1fr;">
         {items.map((item, i) => {
           const isFirst = i === 0;
           const isLast = i === items.length - 1;
@@ -77,7 +77,7 @@ function formatDate(ym: string): string {
       </div>
 
       {/* モバイル: 縦積み（md 未満） */}
-      <div class="md:hidden">
+      <div class="!block md:!hidden">
         {items.map((item, i) => (
           <TimelineItem
             organization={item.data.organization}

--- a/src/components/organisms/SkillsGrid.astro
+++ b/src/components/organisms/SkillsGrid.astro
@@ -30,7 +30,7 @@ const skillsByCategory = Object.fromEntries(
   <div class="flex flex-col gap-4">
     {categories.map(({ key, label }) => (
       <div>
-        <p class="text-sm md:text-base font-mono mb-2 text-text-secondary">{label}</p>
+        <p class="text-xs uppercase tracking-wider text-base-content font-semibold mb-2">{label}</p>
         <div class="flex flex-wrap gap-1">
           {skillsByCategory[key].map(skill => (
             <SkillItem

--- a/src/pages/catalog.astro
+++ b/src/pages/catalog.astro
@@ -345,6 +345,101 @@ const skillsByCategory = Object.fromEntries(
       <ActivitySection />
     </section>
 
+    <!-- ===== Before/After: #41-1 Skills カテゴリ見出し階層表現 ===== -->
+    <div class="border rounded-2xl p-4 space-y-4" style="border-color: oklch(0.88 0.008 150);">
+      <p class="text-xs font-mono uppercase tracking-wider" style="color: oklch(0.55 0.15 145);">
+        #41-1 Skills カテゴリ見出し: Before / After
+      </p>
+      <div class="flex flex-col gap-6">
+        <div class="space-y-2">
+          <p class="text-xs font-mono" style="color: oklch(0.55 0.010 250);">Before: text-sm font-mono text-text-secondary</p>
+          <div class="rounded-xl p-4 bg-base-content">
+            <p class="text-sm md:text-base font-mono mb-2 text-text-secondary">Cloud</p>
+            <div class="flex flex-wrap gap-1">
+              {skillsByCategory['cloud'].slice(0, 3).map(skill => (
+                <SkillItem name={skill.data.name} icon={skill.data.icon} url={skill.data.url} category={skill.data.category} />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div class="space-y-2">
+          <p class="text-xs font-mono" style="color: oklch(0.55 0.010 250);">After: text-xs uppercase tracking-wider font-semibold text-base-content</p>
+          <div class="rounded-xl p-4 bg-base-content">
+            <p class="text-xs uppercase tracking-wider text-base-content font-semibold mb-2">Cloud</p>
+            <div class="flex flex-wrap gap-1">
+              {skillsByCategory['cloud'].slice(0, 3).map(skill => (
+                <SkillItem name={skill.data.name} icon={skill.data.icon} url={skill.data.url} category={skill.data.category} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Before/After: #41-2 Bento Grid gap 調整 ===== -->
+    <div class="border rounded-2xl p-4 space-y-4" style="border-color: oklch(0.88 0.008 150);">
+      <p class="text-xs font-mono uppercase tracking-wider" style="color: oklch(0.55 0.15 145);">
+        #41-2 Bento Grid gap: Before / After
+      </p>
+      <div class="flex flex-col gap-6">
+        <div class="space-y-2">
+          <p class="text-xs font-mono" style="color: oklch(0.55 0.010 250);">Before: gap-4 md:gap-5</p>
+          <div class="flex gap-4 md:gap-5">
+            <div class="flex-1 h-16 rounded-xl" style="background: var(--color-surface); box-shadow: 0 1px 4px var(--color-shadow-sm);"></div>
+            <div class="flex-1 h-16 rounded-xl" style="background: var(--color-surface); box-shadow: 0 1px 4px var(--color-shadow-sm);"></div>
+            <div class="flex-1 h-16 rounded-xl" style="background: var(--color-surface); box-shadow: 0 1px 4px var(--color-shadow-sm);"></div>
+          </div>
+        </div>
+        <div class="space-y-2">
+          <p class="text-xs font-mono" style="color: oklch(0.55 0.010 250);">After: gap-6</p>
+          <div class="flex gap-6">
+            <div class="flex-1 h-16 rounded-xl" style="background: var(--color-surface); box-shadow: 0 1px 4px var(--color-shadow-sm);"></div>
+            <div class="flex-1 h-16 rounded-xl" style="background: var(--color-surface); box-shadow: 0 1px 4px var(--color-shadow-sm);"></div>
+            <div class="flex-1 h-16 rounded-xl" style="background: var(--color-surface); box-shadow: 0 1px 4px var(--color-shadow-sm);"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Before/After: #41-3 Blog セクション統合 ===== -->
+    <div class="border rounded-2xl p-4 space-y-4" style="border-color: oklch(0.88 0.008 150);">
+      <p class="text-xs font-mono uppercase tracking-wider" style="color: oklch(0.55 0.15 145);">
+        #41-3 Blog セクション統合: Before / After
+      </p>
+      <div class="flex flex-col gap-6">
+        <div class="space-y-2">
+          <p class="text-xs font-mono" style="color: oklch(0.55 0.010 250);">Before: AWS Blog + Other を分離表示、SeeAllButton x2</p>
+          <div class="rounded-xl p-4 space-y-3" style="background: var(--color-surface);">
+            <p class="text-sm font-mono" style="color: var(--color-text-muted);">AWS Blog</p>
+            <div class="flex gap-2">
+              <div class="w-24 h-12 rounded-lg" style="background: var(--color-border);"></div>
+              <div class="w-24 h-12 rounded-lg" style="background: var(--color-border);"></div>
+              <div class="w-16 h-12 rounded-lg flex items-center justify-center text-xs" style="background: var(--color-primary-content); color: var(--color-primary); border: 1px solid var(--color-primary);">全てを見る</div>
+            </div>
+            <hr style="border-color: var(--color-border);" />
+            <p class="text-sm font-mono" style="color: var(--color-text-muted);">Other</p>
+            <div class="flex gap-2">
+              <div class="w-24 h-12 rounded-lg" style="background: var(--color-border);"></div>
+              <div class="w-16 h-12 rounded-lg flex items-center justify-center text-xs" style="background: var(--color-primary-content); color: var(--color-primary); border: 1px solid var(--color-primary);">全てを見る</div>
+            </div>
+          </div>
+        </div>
+        <div class="space-y-2">
+          <p class="text-xs font-mono" style="color: oklch(0.55 0.010 250);">After: 統合リスト (最新5件) + SeeAllButton x1 (primary塗りつぶし)</p>
+          <div class="rounded-xl p-4 space-y-3" style="background: var(--color-surface);">
+            <div class="flex gap-2">
+              <div class="w-24 h-12 rounded-lg" style="background: var(--color-border);"></div>
+              <div class="w-24 h-12 rounded-lg" style="background: var(--color-border);"></div>
+              <div class="w-24 h-12 rounded-lg" style="background: var(--color-border);"></div>
+              <div class="w-24 h-12 rounded-lg" style="background: var(--color-border);"></div>
+              <div class="w-24 h-12 rounded-lg" style="background: var(--color-border);"></div>
+              <div class="w-16 h-12 rounded-lg flex items-center justify-center text-xs" style="background: var(--color-primary); color: var(--color-primary-content); border: 1px solid var(--color-primary);">全てを見る</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script>
       function initSkeletons() {
         document.querySelectorAll('.skeleton-img').forEach((wrapper) => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,10 +16,10 @@ const socialLinks = [
 ---
 
 <BaseLayout>
-  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-4 md:gap-5">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-6">
 
     <!-- 行1: Hero × SNS -->
-    <div class="grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-5 items-stretch">
+    <div class="grid grid-cols-1 md:grid-cols-12 gap-6 items-stretch">
       <div class="md:col-span-8 flex" data-animate>
         <HeroSection />
       </div>
@@ -37,7 +37,7 @@ const socialLinks = [
     </div>
 
     <!-- 行2: Career × Skills -->
-    <div class="grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-5 items-stretch">
+    <div class="grid grid-cols-1 md:grid-cols-12 gap-6 items-stretch">
       <div class="md:col-span-4 flex" data-animate>
         <CareerTimeline showAll={false} />
       </div>


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @yosse95ai :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## 概要

Issue #41 の 4 つのデザイン改善課題をすべて修正しました。

## 変更内容

### #1 Skills カードのカテゴリ見出し階層表現
- カテゴリ見出し（Cloud / Language 等）のスタイルを変更
- Before: `text-sm font-mono text-text-secondary`
- After: `text-xs uppercase tracking-wider text-base-content font-semibold`
- 色ではなく構造（大文字・トラッキング・ウェイト）で階層を表現

### #2 Bento Grid の gap 調整
- グリッドコンテナの gap を `gap-4 md:gap-5` から `gap-6` に拡大
- カード境界がパーティクル背景に溶けにくくなる

### #3 Blog セクションの統合・最新 5 件表示
- AWS Blog と Other を統合し、日付降順で最新 5 件を横スクロール表示
- 「全てを見る」カードを 1 つに集約（primary 塗りつぶしスタイル）

### #4 History ページ：Career セクションの重複表示バグ修正
- レスポンシブ表示クラスの DaisyUI による上書きを防止し、重複レンダリングを解消

## カタログ
- `catalog.astro` に Before/After 比較セクションを追加（#1, #2, #3）

## テスト
- `npm run build`: PASS（5 ページビルド成功）
- `npx vitest run`: PASS（60 テスト / 7 ファイル）

Closes #41