### PR TITLE
docs: Phase 3 - Bun 移行に伴うドキュメント / steering の更新

### DIFF
--- a/.kiro/specs/bun-migration/design.md
+++ b/.kiro/specs/bun-migration/design.md
@@ -368,6 +368,19 @@ postinstall はブロックされる**。許可と防御のバランスとして
 `package-manager: bun` を明示すると action は `Setup Bun` + `Setup Node (Bun)` を実行し、
 install は `bun install`、build は `bun run build` になる。実行ランタイムは Node のまま。
 
+加えて `deploy` job には `if: github.ref == 'refs/heads/master'` のブランチガードを追加する。
+
+```diff
+   deploy:
+     needs: build
++    if: github.ref == 'refs/heads/master'
+     runs-on: ubuntu-latest
+```
+
+feature branch から `workflow_dispatch` で検証実行すると、`github-pages` 環境のブランチ保護により
+deployment レコードが `failure` になり PR に失敗デプロイとして表示されるため、build job のみを
+走らせて deploy job はスキップさせる。
+
 #### 2-2. `.github/workflows/update-aws-blog.yml`
 
 現状は `checkout@v4` / `setup-node@v4` である点に注意（`deploy.yml` は v5）。

--- a/.kiro/specs/bun-migration/tasks.md
+++ b/.kiro/specs/bun-migration/tasks.md
@@ -303,7 +303,7 @@ Phase ごとに独立したコミットを作り、ロールバックが Phase �
     - push はユーザーの明示的な承認を得てから実行する
     - _要件: 5.6, 12.7_
 
-- [ ] 13. 最終チェックポイント
+- [x] 13. 最終チェックポイント
   - すべてのテストがパスし、P1〜P5 の検証結果が揃っていることを確認し、疑問があればユーザーに確認する。
 
 ## Notes
@@ -407,6 +407,23 @@ Phase ごとに独立したコミットを作り、ロールバックが Phase �
   - 12.5 `.kiro/specs/` 配下の差分は本 spec の `design.md` のみで、既存 spec 群（履歴文書）の差分は **0 件**
   - 追随修正: `design.md` の Phase 2 セクションに deploy job の
     `if: github.ref == 'refs/heads/master'` を反映し、追加理由を注記（design と実装の差分を解消）
+- **最終チェックポイント（Task 13）の結果: ユーザー承認により完了**
+  - P1（成果物同一性）: **合格**。ローカル `bun run build` の `dist/` 25 ファイルが Node ベースラインと
+    SHA-256 完全一致（7.1）。CI の Pages artifact も 25 ファイルで一致（10.5）
+  - P2（テスト件数）: **合格**。9 files / 86 tests がローカル（7.2）と CI（10.2）の双方で
+    `Baseline_Test_Count` と一致
+  - P3（実行ランタイム）: **合格**。テストプロセス内で `process.versions.bun` は `undefined`、
+    `process.versions.node` は 24 系（7.2）
+  - P4（OGP のサイレント劣化検出）: **ローカルのみ合格**。3.4（Node 環境）と
+    7.4（`bun scripts/refresh-ogp-cache.ts`）で検証済みだが、CI 実行ログでの検証（10.6 / 要件 7.5）は未充足
+  - P5（切り戻し可能性）: **合格**。`npm ci --dry-run` が終了コード 0、`package-lock.json` は残置（7.7）
+  - **未充足のまま残す要件**: 13.4 / 13.6（Linux x64 CI での 5 系統の展開プラットフォーム記録 = 10.4）と
+    7.5（CI 実行ログでの P4 検証 = 10.6）。いずれも記録項目であり、移行の主目的
+    （macOS ARM64 生成の `bun.lock` が Linux x64 CI の `--frozen-lockfile` を通る）は 10.3 で検証済み
+  - 本番デプロイの実績: `master` へのマージ（merge commit `9479c2c`）で走った run `31961683874` が
+    build / deploy ともに成功し、`/` `/gallery/` `/history/` が HTTP 200、`/catalog/` が 404 であることを確認。
+    Bun 経路での本番デプロイが成立
+  - Phase 3 の PR: #70（ブランチ `docs/bun-migration-phase3`、コミット `9348ca8`）
 
 ## Task Dependency Graph
 

--- a/.kiro/specs/bun-migration/tasks.md
+++ b/.kiro/specs/bun-migration/tasks.md
@@ -259,11 +259,11 @@ Phase ごとに独立したコミットを作り、ロールバックが Phase �
     - 取得成功件数・取得失敗件数が出力されていることを確認する
     - _要件: 7.4, 7.5_
 
-- [ ] 11. チェックポイント - Phase 2 完了
+- [x] 11. チェックポイント - Phase 2 完了
   - CI が成功していることを確認し、疑問があればユーザーに確認する。
 
-- [ ] 12. Phase 3: ドキュメント / steering の更新
-  - [ ] 12.1 `doc/blueprint.md` を更新する
+- [x] 12. Phase 3: ドキュメント / steering の更新
+  - [x] 12.1 `doc/blueprint.md` を更新する
     - 技術スタック表: パッケージ管理を Bun（ランタイムは Node を維持）に、
       Node バージョン管理を nvm（`.nvmrc`）/ Bun は `.bun-version` に更新する
     - アニメーション行を Tailwind `animate-*` + CSS + Astro CSS View Transitions の 3 要素を含む記述に更新する
@@ -272,7 +272,7 @@ Phase ごとに独立したコミットを作り、ロールバックが Phase �
       の 4 エントリを記載する
     - _要件: 11.1, 11.2, 11.3_
 
-  - [ ] 12.2 `.kiro/steering/tech.md` を更新する
+  - [x] 12.2 `.kiro/steering/tech.md` を更新する
     - テスト実行節: `bun run test` / `bunx vitest run <path>` に更新し、
       `bun test` が `vi.*` API 非対応のため使用不可である旨を明記する
     - デプロイ節: `oven-sh/setup-bun@v2` + `withastro/action@v6`（`package-manager: bun`）+ `actions/deploy-pages@v4`
@@ -282,23 +282,23 @@ Phase ごとに独立したコミットを作り、ロールバックが Phase �
       `bunfig.toml` の `[run] bun = true` を設定しない方針と `--bun` を付与しない方針の 2 点を記載する
     - _要件: 11.4, 11.5, 11.6, 11.7_
 
-  - [ ] 12.3 `.kiro/steering/development-standard.md` の rule-1 を更新する
+  - [x] 12.3 `.kiro/steering/development-standard.md` の rule-1 を更新する
     - 既存の Node 確認手順（`cat ./.nvmrc` / `node --version` / `nvm use`）に続けて、
       `cat ./.bun-version` / `bun --version` / 不一致時の `bun upgrade --to <version>` の手順を追加する
     - _要件: 9.6, 11.8_
 
-  - [ ] 12.4 lockfile 乖離の運用ルールを記載する
+  - [x] 12.4 lockfile 乖離の運用ルールを記載する
     - `bun update` 実行時に `bun.lock` のみが更新され `package-lock.json` と乖離することを明記する
     - 乖離の扱い（同期する / 乖離を許容しロールバック時に再生成する）の運用ルールを記載する
     - 記載先は 12.2 で更新した `.kiro/steering/tech.md` のランタイム節とする
     - _要件: 11.10_
 
-  - [ ] 12.5 `.kiro/specs/` に差分がないことを確認する
+  - [x] 12.5 `.kiro/specs/` に差分がないことを確認する
     - `.kiro/specs/` 配下の既存 spec 群（履歴文書）が本作業で変更されていないこと（差分 0 ファイル）を確認する
     - 本 spec の `.kiro/specs/bun-migration/` 配下は対象外
     - _要件: 11.9_
 
-  - [ ] 12.6 Phase 3 をコミットして push をユーザー確認する
+  - [x] 12.6 Phase 3 をコミットして push をユーザー確認する
     - コミット前にユーザープロファイル（Individual / AWS）を確認し `git config` を設定する
     - push はユーザーの明示的な承認を得てから実行する
     - _要件: 5.6, 12.7_
@@ -385,6 +385,28 @@ Phase ごとに独立したコミットを作り、ロールバックが Phase �
     deployment レコードが作られない
   - Phase 2 の検証結果（10.2 / 10.3 / 10.5）は build job のみを根拠としているため再検証は不要。
     `design.md` の `deploy.yml` 構成記述にはこの `if` 条件が含まれていない点を差分として記録しておく
+- **Phase 3 の実施記録（ブランチ `docs/bun-migration-phase3`、master `65069c7` から分岐）**
+  - 12.1 `doc/blueprint.md`: 技術スタック表を「アニメーション = Tailwind `animate-*` + CSS transition +
+    Astro CSS View Transitions」「パッケージ管理 = Bun（ランタイムは Node を維持）」
+    「バージョン管理 = Node は nvm（`.nvmrc`）、Bun は `.bun-version`」に更新。
+    ディレクトリ構成のツリー末尾に `bun.lock` / `package-lock.json`（切り戻し用に残置の注記付き）/
+    `.bun-version` / `.nvmrc` の 4 エントリを記載し、`└──` の重複記法も修正
+  - 12.2 `.kiro/steering/tech.md`: テスト実行を `bun run test` / `bunx vitest run <path>` に更新し
+    `bun test` が `vi.*` API 非対応で使用不可である旨を明記。デプロイ節の `withastro/action@v5` の誤記を
+    **v6 に修正**し、`oven-sh/setup-bun@v2` + `withastro/action@v6`（`package-manager: bun`）+
+    `actions/deploy-pages@v4` の 3 要素と deploy job のブランチガードを記載。
+    開発コマンドを `bun install` / `bun run dev` / `bun run build` / `bun run preview` に更新。
+    「Node バージョン」節を「ランタイムとパッケージマネージャ」節に置き換え、
+    `bunfig.toml` の `[run] bun = true` を設定しない方針と `--bun` を付けない方針を記載
+  - 12.3 `.kiro/steering/development-standard.md`: rule-1 を「Node と Bun のバージョン確認」に拡張し、
+    `### Node`（既存 3 ステップ）+ `### Bun`（`cat ./.bun-version` / `bun --version` /
+    不一致時 `bun upgrade --to <version>`）の構成に更新
+  - 12.4 lockfile 乖離の運用ルール: `tech.md` の「ランタイムとパッケージマネージャ」節に
+    `### lockfile の運用` サブ節を新設。`bun update` で `bun.lock` のみ更新され `package-lock.json` と
+    乖離すること、**乖離は許容し npm ロールバック時に `package-lock.json` を再生成する**運用を明記
+  - 12.5 `.kiro/specs/` 配下の差分は本 spec の `design.md` のみで、既存 spec 群（履歴文書）の差分は **0 件**
+  - 追随修正: `design.md` の Phase 2 セクションに deploy job の
+    `if: github.ref == 'refs/heads/master'` を反映し、追加理由を注記（design と実装の差分を解消）
 
 ## Task Dependency Graph
 

--- a/.kiro/steering/development-standard.md
+++ b/.kiro/steering/development-standard.md
@@ -5,7 +5,14 @@ inclusion: always
 以下のルールを必ず遵守すること。
 
 ## rule-1
-会話セッションの最初に、必ず、Node のバージョン確認し、一致していなければ切り替えること。
+会話セッションの最初に、必ず、Node と Bun のバージョンを確認し、一致していなければ切り替えること。
+
+### Node
 1. NVMのバージョンを確認　`cat ./.nvmrc`
 2. LocalのNodeバージョン確認 `node --version`
 3. 整合していなければ、NVMのバージョンに変更する `nvm use`
+
+### Bun
+4. 期待する Bun のバージョンを確認 `cat ./.bun-version`
+5. Local の Bun バージョン確認 `bun --version`
+6. 整合していなければ、`.bun-version` の値に合わせる `bun upgrade --to <version>`

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -46,24 +46,36 @@ inclusion: always
 
 ### テスト実行（プロジェクトルートから）
 ```bash
-npx vitest run          # 全テスト（ワンショット）
-npx vitest run <path>   # 特定ファイルのみ
+bun run test            # 全テスト（ワンショット）
+bunx vitest run <path>  # 特定ファイルのみ
 ```
 - `cd` コマンドは使用不可
-- `npm run test -- --run` は `--run` が二重になるため**使わない**
+- **`bun test` は使用不可**。Bun ネイティブランナーは Vitest の `vi.*` API（`vi.mock` / `vi.stubGlobal` 等）に非対応のため、テストは必ず Vitest 経由で実行する
+- `bun run test -- --run` は `--run` が二重になるため**使わない**（`scripts.test` が既に `vitest --run`）
 
 ## デプロイ
 - GitHub Pages（`https://yosse95ai.github.io`）
-- GitHub Actions: `withastro/action@v5` + `actions/deploy-pages@v4`
+- GitHub Actions: `oven-sh/setup-bun@v2`（`bun-version-file: .bun-version`）+ `withastro/action@v6`（`package-manager: bun` / `node-version: '24'`）+ `actions/deploy-pages@v4`
 - `master` ブランチへの push でトリガー
+- deploy job は `if: github.ref == 'refs/heads/master'` でガードしており、feature branch からは実行されない
 - **`git push` は自律的に実行しない**（必ずユーザー確認を取る）
 
 ## 開発コマンド
 ```bash
-npm run dev      # 開発サーバー起動
-npm run build    # 本番ビルド
-npm run preview  # ビルド結果プレビュー
+bun install      # 依存インストール
+bun run dev      # 開発サーバー起動
+bun run build    # 本番ビルド
+bun run preview  # ビルド結果プレビュー
 ```
 
-## Node バージョン
-`.nvmrc` で管理。`nvm use` で切り替え。
+## ランタイムとパッケージマネージャ
+- ランタイムは **Node 24**。`.nvmrc` で管理し `nvm use` で切り替える
+- パッケージマネージャは **Bun 1.3.14**。`.bun-version` で管理し、`package.json` の `packageManager` と一致させる
+- `bunfig.toml` の `[run] bun = true` は**設定しない**
+- スクリプト実行時に `--bun` フラグは**付けない**
+- 上記 2 点はいずれも Astro / Vitest を Node ランタイムで動かし続けるための方針
+
+### lockfile の運用
+- `bun update` を実行すると `bun.lock` のみが更新され、`package-lock.json` と乖離する
+- `package-lock.json` は npm への切り戻し用に意図的に残置している
+- 運用ルール: **乖離は許容する**。都度の同期は行わず、npm へロールバックする場合に `package-lock.json` を再生成する

--- a/doc/blueprint.md
+++ b/doc/blueprint.md
@@ -202,9 +202,9 @@ AWSに勤務するエンジニアの個人紹介サイト。主にKiroのブロ�
 | 言語 | TypeScript（strict mode） |
 | スタイリング | Tailwind CSS v4（`@tailwindcss/vite`） |
 | UIコンポーネント | DaisyUI v5（Tailwind v4ネイティブ、React不要） |
-| アニメーション | Motion（Vanilla JS API）+ Astro CSS View Transitions |
-| パッケージ管理 | npm |
-| Nodeバージョン管理 | nvm |
+| アニメーション | Tailwind `animate-*` + CSS transition + Astro CSS View Transitions |
+| パッケージ管理 | Bun（ランタイムは Node を維持） |
+| バージョン管理 | Node は nvm（`.nvmrc`）、Bun は `.bun-version` |
 | コンテンツ管理 | Astro Content Collections（Content Layer API） |
 | アイコン | `@iconify/astro` + `@iconify-json/devicon` + `@iconify-json/simple-icons` |
 | デプロイ | GitHub Actions（`withastro/action`）→ GitHub Pages |
@@ -266,8 +266,10 @@ yosse95ai.github.io/
 │   └── styles/global.css
 ├── astro.config.mjs
 ├── tsconfig.json
-└── package-lock.json
-└── .nvmrc
+├── bun.lock
+├── package-lock.json      # 切り戻し用に残置
+├── .bun-version           # Bun のバージョン
+└── .nvmrc                 # Node のバージョン
 ```
 
 ---


### PR DESCRIPTION
bun-migration spec の Phase 3（Task 12.1〜12.6）。ドキュメントのみの変更で、コード・CI・ビルド成果物には影響しません。

## 変更概要

### `doc/blueprint.md`（12.1）
- 技術スタック表: パッケージ管理を **Bun**（ランタイムは Node を維持）、バージョン管理を Node は nvm（`.nvmrc`）/ Bun は `.bun-version` に更新
- アニメーション行から `Motion` の記載を除去し、Tailwind `animate-*` + CSS transition + Astro CSS View Transitions に更新
- ディレクトリ構成に `bun.lock` / `package-lock.json`（切り戻し用に残置の注記付き）/ `.bun-version` / `.nvmrc` を追加。`└──` の重複記法も修正

### `.kiro/steering/tech.md`（12.2 / 12.4）
- テスト実行を `bun run test` / `bunx vitest run <path>` に更新。`bun test` は Vitest の `vi.*` API 非対応のため使用不可であることを明記
- デプロイ節: `withastro/action@v5` の**誤記を v6 に修正**。`oven-sh/setup-bun@v2` + `withastro/action@v6`（`package-manager: bun`）+ `actions/deploy-pages@v4` の 3 要素と deploy job のブランチガードを記載
- 開発コマンドを `bun install` / `bun run dev` / `bun run build` / `bun run preview` に更新
- 「Node バージョン」節を「ランタイムとパッケージマネージャ」節に置き換え、`bunfig.toml` の `[run] bun = true` を設定しない方針と `--bun` を付けない方針を記載
- `### lockfile の運用` を新設。`bun update` で `bun.lock` のみ更新され `package-lock.json` と乖離すること、**乖離は許容し npm ロールバック時に再生成する**運用ルールを明記

### `.kiro/steering/development-standard.md`（12.3）
- rule-1 を Node と Bun の 2 段構成に拡張（`cat ./.bun-version` / `bun --version` / 不一致時 `bun upgrade --to <version>`）

### `.kiro/specs/bun-migration/`
- `design.md`: deploy job の `if: github.ref == 'refs/heads/master'` を反映し追加理由を注記（design と実装の差分を解消）
- `tasks.md`: Task 11 / 12.1〜12.6 を完了にし、Phase 3 の実施記録を Notes に追記

## 検証内容

- `cat ./.bun-version` = `1.3.14` / `bun --version` = `1.3.14`、`.nvmrc` = `24` / `node --version` = `v24.19.0` の一致を実機確認
- `tech.md` に `npx` / `withastro/action@v5` の残存が 0 件であることを grep で確認
- 記載コマンドが `package.json` の scripts と整合していることを確認
- 12.5: `.kiro/specs/` 配下の差分は本 spec の `design.md` のみ、既存 spec 群の差分は 0 件

## 影響範囲

ドキュメントと steering のみ。`src/` / `scripts/` / `.github/workflows/` / `package.json` は無変更のため、サイト出力とテストに変化はありません。