### PR TITLE
ci: PR で CI を実行し、ビルド出力のスモークチェックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+# 同じ PR に連続で push した場合は古い実行を打ち切る
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: 依存関係のインストール
+        run: bun install --frozen-lockfile
+
+      - name: ユニットテスト
+        run: bun run test
+
+      - name: 型チェック
+        run: bun run check
+
+      - name: ビルド
+        run: bun run build
+
+      - name: ビルド出力のスモークチェック
+        run: bun run smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: CI
 
 on:
+  # base ブランチを問わず全ての PR で実行する
+  # （branches フィルタは base ブランチに対する条件であり、head ブランチ名は問わない）
   pull_request:
+  # マージ後の master も検証する。deploy.yml は test しか通していないため
+  # 型チェックとスモークはここで担保する（README のバッジもこの結果を指す）
+  push:
     branches: [master]
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # yosse95ai.github.io
 
-![Deploy](https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/deploy.yml/badge.svg)
+[![CI][ci-badge]][ci] [![Deploy][deploy-badge]][deploy]
 [![Built with Kiro][kiro-badge]][kiro]
 
 HomePage URL：https://yosse95ai.github.io
 
+[ci]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/ci.yml
+[ci-badge]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/ci.yml/badge.svg
+[deploy]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/deploy.yml
+[deploy-badge]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/deploy.yml/badge.svg
 [kiro]: https://kiro.dev/
 [kiro-badge]: https://img.shields.io/badge/Built_with-Kiro-8A3FFC?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyNCI+PHBhdGggZD0iTTMuOCAxOC41N0MxLjMyIDI0LjA2IDYuNiAyNS40MyAxMC40OSAyMi4yMkMxMS42MyAyNS44MiAxNS45MyAyMy4xNCAxNy40NyAyMC4zNEMyMC44NiAxNC4xOSAxOS40OSA3LjkxIDE5LjE0IDYuNjJDMTYuNzIgLTIuMjEgNC42NyAtMi4yMiAyLjYgNi42NkMyLjExIDguMjIgMi4xIDkuOTkgMS44MyAxMS44MkMxLjY5IDEyLjc1IDEuNTkgMTMuMzQgMS4yMyAxNC4zMUMxLjAzIDE0Ljg3IDAuNzUgMTUuMzcgMC4zIDE2LjIxQy0wLjM5IDE3LjUxIC0wLjEgMjAuMDIgMy40NiAxOC43MlYxOC43MkwzLjggMTguNTdaIiBmaWxsPSJ3aGl0ZSIvPjxwYXRoIGQ9Ik0xMC45NiAxMC40NEM5Ljk3IDEwLjQ0IDkuODIgOS4yNiA5LjgyIDguNTVDOS44MiA3LjkyIDkuOTQgNy40MSAxMC4xNSA3LjA5QzEwLjM0IDYuODEgMTAuNjIgNi42NyAxMC45NiA2LjY3QzExLjMxIDYuNjcgMTEuNiA2LjgxIDExLjgxIDcuMUMxMi4wNSA3LjQzIDEyLjE4IDcuOTMgMTIuMTggOC41NUMxMi4xOCA5Ljc0IDExLjcyIDEwLjQ0IDEwLjk2IDEwLjQ0SDEwLjk2WiIgZmlsbD0iYmxhY2siLz48cGF0aCBkPSJNMTUuMDMgMTAuNDRDMTQuMDQgMTAuNDQgMTMuODkgOS4yNiAxMy44OSA4LjU1QzEzLjg5IDcuOTIgMTQuMDEgNy40MSAxNC4yMiA3LjA5QzE0LjQxIDYuODEgMTQuNjkgNi42NyAxNS4wMyA2LjY3QzE1LjM4IDYuNjcgMTUuNjcgNi44MSAxNS44OCA3LjFDMTYuMTIgNy40MyAxNi4yNSA3LjkzIDE2LjI1IDguNTVDMTYuMjUgOS43NCAxNS43OSAxMC40NCAxNS4wMyAxMC40NEgxNS4wM1oiIGZpbGw9ImJsYWNrIi8+PC9zdmc+Cg==

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 HomePage URL：https://yosse95ai.github.io
 
 [ci]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/ci.yml
-[ci-badge]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/ci.yml/badge.svg
+[ci-badge]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/ci.yml/badge.svg?branch=master
 [deploy]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/deploy.yml
 [deploy-badge]: https://github.com/yosse95ai/yosse95ai.github.io/actions/workflows/deploy.yml/badge.svg
 [kiro]: https://kiro.dev/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "astro build && rm -rf dist/catalog",
     "preview": "astro preview",
     "test": "vitest --run",
+    "check": "astro check",
+    "smoke": "bun scripts/smoke-build.ts",
     "ogp:refresh": "bun scripts/refresh-ogp-cache.ts",
     "blog:update": "bun scripts/update-aws-blog.ts",
     "astro": "astro"

--- a/scripts/smoke-build.ts
+++ b/scripts/smoke-build.ts
@@ -11,17 +11,22 @@
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { sanitizeForLog } from './lib/sanitize.js';
 
 const DIST = process.env.SMOKE_DIST_DIR ?? 'dist';
 const SITE = 'https://yosse95ai.github.io';
 
 let failures = 0;
 
-const section = (title: string) => console.log(`\n▶ ${title}`);
-const ok = (message: string) => console.log(`  ✅ ${message}`);
-const ng = (message: string, detail?: string) => {
+// 記事 ID や URL は RSS フィード由来の外部データなので、ログ出力前にサニタイズする
+// （Log Injection / CWE-117 対策。リポジトリ全体で sanitizeForLog を通す方針）
+const section = (title: string) => console.log(`\n▶ ${sanitizeForLog(title)}`);
+const ok = (message: string) => console.log(`  ✅ ${sanitizeForLog(message)}`);
+/** 詳細は 1 要素 1 行として渡す（サニタイズで改行が失われるため文字列連結にしない） */
+const ng = (message: string, details: string[] = []) => {
   failures++;
-  console.error(`  ❌ ${message}${detail ? `\n     ${detail.replace(/\n/g, '\n     ')}` : ''}`);
+  const body = details.map((line) => `\n     ${sanitizeForLog(line)}`).join('');
+  console.error(`  ❌ ${sanitizeForLog(message)}${body}`);
 };
 
 const distFile = (path: string) => join(DIST, path);
@@ -35,7 +40,7 @@ const readJson = <T>(path: string): T => JSON.parse(readFileSync(path, 'utf-8'))
 const checkOrder = (html: string, needles: string[], label: string) => {
   const missing = needles.filter((needle) => !html.includes(needle));
   if (missing.length > 0) {
-    ng(`${label}: 出力に存在しない項目がある`, missing.join('\n'));
+    ng(`${label}: 出力に存在しない項目がある`, missing);
     return;
   }
   const actual = [...needles].sort((a, b) => html.indexOf(a) - html.indexOf(b));
@@ -43,10 +48,10 @@ const checkOrder = (html: string, needles: string[], label: string) => {
     ok(`${label}（${needles.length} 件が期待どおりの順序）`);
     return;
   }
-  ng(
-    `${label}: 並び順が期待と異なる`,
-    `期待: ${needles.join(' > ')}\n実際: ${actual.join(' > ')}`,
-  );
+  ng(`${label}: 並び順が期待と異なる`, [
+    `期待: ${needles.join(' > ')}`,
+    `実際: ${actual.join(' > ')}`,
+  ]);
 };
 
 // ---------------------------------------------------------------- ページの生成
@@ -94,7 +99,10 @@ section('sitemap');
   if (locs.length === expected.length && expected.every((url) => locs.includes(url))) {
     ok(`${locs.length} URL: ${locs.join(', ')}`);
   } else {
-    ng('sitemap の URL が期待と異なる', `期待: ${expected.join(', ')}\n実際: ${locs.join(', ')}`);
+    ng('sitemap の URL が期待と異なる', [
+      `期待: ${expected.join(', ')}`,
+      `実際: ${locs.join(', ')}`,
+    ]);
   }
 }
 
@@ -146,7 +154,10 @@ section('Blog カード（publishedAt 降順、同値は id 昇順）');
     const articles = readJson<Article[]>(`src/data/blog/${file}`);
     const missing = articles.filter((a) => !history.includes(`href="${a.externalUrl}"`));
     if (missing.length > 0) {
-      ng(`${label}: 記事が出力されていない`, missing.map((a) => a.id).join(', '));
+      ng(
+        `${label}: 記事が出力されていない`,
+        missing.map((a) => a.id),
+      );
       continue;
     }
     ok(`${label}: ${articles.length} 件すべてが出力されている`);

--- a/scripts/smoke-build.ts
+++ b/scripts/smoke-build.ts
@@ -1,0 +1,191 @@
+/**
+ * ビルド成果物のスモークチェック
+ *
+ * ユニットテストでは検知できない「生成された HTML の回帰」を検査する。
+ * 特に getCollection() の返却順はライブラリの実装に依存して静かに変わるため
+ * （Astro 5 -> 6 で JSON 定義順から id 順に変わった実績がある）、
+ * データファイルから期待する並び順を組み立てて実際の出力と照合する。
+ *
+ * 使い方: bun run build && bun run smoke
+ * 検査対象のディレクトリは SMOKE_DIST_DIR で差し替えられる（失敗パスの検証用）。
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIST = process.env.SMOKE_DIST_DIR ?? 'dist';
+const SITE = 'https://yosse95ai.github.io';
+
+let failures = 0;
+
+const section = (title: string) => console.log(`\n▶ ${title}`);
+const ok = (message: string) => console.log(`  ✅ ${message}`);
+const ng = (message: string, detail?: string) => {
+  failures++;
+  console.error(`  ❌ ${message}${detail ? `\n     ${detail.replace(/\n/g, '\n     ')}` : ''}`);
+};
+
+const distFile = (path: string) => join(DIST, path);
+const readDist = (path: string) => readFileSync(distFile(path), 'utf-8');
+const readJson = <T>(path: string): T => JSON.parse(readFileSync(path, 'utf-8')) as T;
+
+/**
+ * needles が html 内にこの順序で出現することを検査する。
+ * 欠落と順序違いを区別して報告する。
+ */
+const checkOrder = (html: string, needles: string[], label: string) => {
+  const missing = needles.filter((needle) => !html.includes(needle));
+  if (missing.length > 0) {
+    ng(`${label}: 出力に存在しない項目がある`, missing.join('\n'));
+    return;
+  }
+  const actual = [...needles].sort((a, b) => html.indexOf(a) - html.indexOf(b));
+  if (actual.every((needle, i) => needle === needles[i])) {
+    ok(`${label}（${needles.length} 件が期待どおりの順序）`);
+    return;
+  }
+  ng(
+    `${label}: 並び順が期待と異なる`,
+    `期待: ${needles.join(' > ')}\n実際: ${actual.join(' > ')}`,
+  );
+};
+
+// ---------------------------------------------------------------- ページの生成
+
+const PAGES = [
+  'index.html',
+  '404.html',
+  'gallery/index.html',
+  'history/index.html',
+  'sitemap-index.xml',
+  'sitemap-0.xml',
+];
+
+section('ページの生成');
+for (const page of PAGES) {
+  if (existsSync(distFile(page))) ok(page);
+  else ng(`${page} が生成されていない`);
+}
+
+// 開発用のコンポーネントカタログは build スクリプトで削除される想定
+if (existsSync(distFile('catalog'))) {
+  ng('dist/catalog が残っている（開発用カタログは公開しない）');
+} else {
+  ok('dist/catalog が削除されている');
+}
+
+if (failures > 0) {
+  console.error('\nページが生成されていないため、以降の検査を中止します。');
+  process.exit(1);
+}
+
+section('各ページの <title>');
+for (const page of PAGES.filter((p) => p.endsWith('.html') && p !== '404.html')) {
+  const title = readDist(page).match(/<title>([^<]*)<\/title>/)?.[1]?.trim();
+  if (title) ok(`${page}: ${title}`);
+  else ng(`${page}: <title> が空、または存在しない`);
+}
+
+// -------------------------------------------------------------------- sitemap
+
+section('sitemap');
+{
+  const locs = [...readDist('sitemap-0.xml').matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+  const expected = [`${SITE}/`, `${SITE}/catalog/`, `${SITE}/gallery/`, `${SITE}/history/`];
+  if (locs.length === expected.length && expected.every((url) => locs.includes(url))) {
+    ok(`${locs.length} URL: ${locs.join(', ')}`);
+  } else {
+    ng('sitemap の URL が期待と異なる', `期待: ${expected.join(', ')}\n実際: ${locs.join(', ')}`);
+  }
+}
+
+// ------------------------------------------------- コレクションの表示順（本題）
+
+const index = readDist('index.html');
+const gallery = readDist('gallery/index.html');
+const history = readDist('history/index.html');
+
+section('Skills の表示順（skills.json の order 昇順）');
+{
+  type Skill = { id: string; order: number; name: string };
+  const skills = readJson<Skill[]>('src/data/skills/skills.json');
+  const expected = [...skills]
+    .sort((a, b) => a.order - b.order)
+    .map((skill) => `title="${skill.name}"`);
+  checkOrder(index, expected, 'Skills');
+}
+
+section('Gallery の表示順（img.json の order 昇順）');
+{
+  type Image = { id: string; order: number; src: string };
+  const images = readJson<Image[]>('src/data/gallery/img.json');
+  const expected = [...images]
+    .sort((a, b) => a.order - b.order)
+    // 最適化後は /_astro/<元のファイル名>.<hash>.webp になる
+    .map((image) => `/_astro/${image.src.split('/').pop()!.replace(/\.[^.]+$/, '')}.`);
+  checkOrder(gallery, expected, 'Gallery');
+}
+
+section('Speaking の表示順（date 降順）');
+{
+  type Speaking = { id: string; date: string; event: string };
+  const speaking = readJson<Speaking[]>('src/data/speaking/speaking.json');
+  const expected = [...speaking]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    // SpeakingCard は「{年} — {イベント名}」を表示する
+    .map((item) => `>${item.date.slice(0, 4)} — ${item.event}<`);
+  checkOrder(index, expected, 'Speaking');
+}
+
+section('Blog カード（publishedAt 降順、同値は id 昇順）');
+{
+  type Article = { id: string; externalUrl: string; publishedAt?: string };
+  for (const [file, label] of [
+    ['aws-articles.json', 'AWS ブログ'],
+    ['other-articles.json', 'その他ブログ'],
+  ] as const) {
+    const articles = readJson<Article[]>(`src/data/blog/${file}`);
+    const missing = articles.filter((a) => !history.includes(`href="${a.externalUrl}"`));
+    if (missing.length > 0) {
+      ng(`${label}: 記事が出力されていない`, missing.map((a) => a.id).join(', '));
+      continue;
+    }
+    ok(`${label}: ${articles.length} 件すべてが出力されている`);
+
+    // publishedAt を持つ記事同士の相対順序のみ検証する
+    // （OGP から日付を補完している記事はデータファイルだけでは順序が確定しないため）
+    const dated = articles.filter((a): a is Required<Article> => Boolean(a.publishedAt));
+    if (dated.length < 2) continue;
+    const expected = [...dated]
+      .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt) || a.id.localeCompare(b.id))
+      .map((a) => `href="${a.externalUrl}"`);
+    checkOrder(history, expected, `${label}の並び`);
+  }
+}
+
+// ---------------------------------------------------------------- アイコン描画
+
+section('アイコンの描画');
+{
+  const svgCount = (index.match(/<svg/g) ?? []).length;
+  if (svgCount >= 10) ok(`svg 要素が ${svgCount} 個`);
+  else ng(`svg 要素が ${svgCount} 個しかない（アイコンの解決に失敗している可能性）`);
+
+  // 多色ロゴは Iconify の正規化で currentColor に置換されることがあるため色を直接検査する
+  const colors = [
+    { label: 'Kiro の紫（thesvg-color:kiro）', value: '#993ff5' },
+    { label: 'Dify の青（local:dify）', value: '#03f' },
+    { label: 'devicon の色（TypeScript）', value: '#007acc' },
+  ];
+  for (const { label, value } of colors) {
+    if (index.includes(value)) ok(`${label}: ${value} が維持されている`);
+    else ng(`${label}: ${value} が出力に無い（currentColor に置換された可能性）`);
+  }
+}
+
+// ------------------------------------------------------------------------ 結果
+
+if (failures > 0) {
+  console.error(`\n❌ スモークチェック失敗: ${failures} 件`);
+  process.exit(1);
+}
+console.log('\n✅ スモークチェック成功: すべての項目が期待どおり');


### PR DESCRIPTION
## 変更概要

PR #74（Astro 7 へのアップグレード）で判明した 2 つの穴を埋める。

1. **PR 上で CI が走っていなかった** — `deploy.yml` が `master` への push のみをトリガーにしていたため、ブランチを push してもワークフローの起動数は 0 件だった。つまり「マージしてから初めて CI が回る」状態で、メジャーアップグレードのような変更では特にリスクが高い
2. **生成 HTML の回帰を検知する手段がなかった** — PR #74 では Astro 6 で `getCollection()` の返却順が JSON 定義順から id 順に変わり、Skills や Gallery の表示順が静かに壊れていた。移行ガイドに記載のない挙動変更で、`master` を別ワークツリーで再ビルドして HTML を目 diff して初めて気づいた。ユニットテストでは検知できない

## 1. PR で CI を実行する（`.github/workflows/ci.yml`）

```
test -> check -> build -> smoke
```

- `on: pull_request` (branches: master) と `workflow_dispatch`
- `concurrency` で同一 PR の古い実行を打ち切る
- `permissions` は `contents: read` のみ。デプロイ権限は `deploy.yml` 側に残したまま
- bun のバージョンは `.bun-version` に追従（`oven-sh/setup-bun@v2`）

`deploy.yml` は変更していない。デプロイ経路に手を入れず、検証だけを追加する方針。

## 2. ビルド出力のスモークチェック（`scripts/smoke-build.ts`）

データファイルから**期待する並び順を組み立てて**実際の出力と照合するのが要点。データが更新されても期待値が自動で追従するため、記事の週次更新などで壊れない。

| 検査項目 | 内容 |
|-|-|
| ページの生成 | 6 種（index / 404 / gallery / history / sitemap 2 つ）と `dist/catalog` が削除されていること |
| `<title>` | 各ページに空でないタイトルがあること |
| sitemap | URL 4 件が期待どおりであること |
| **Skills / Gallery の並び** | `order` 昇順（`skills.json` / `img.json` と照合） |
| **Speaking の並び** | `date` 降順（`speaking.json` と照合） |
| **Blog カード** | 記事が全件出力され、`publishedAt` 降順・同値時は id 昇順であること |
| アイコン | `#993ff5`（Kiro） / `#03f`（Dify） / `#007acc`（devicon）が維持され、svg 要素が 10 個以上あること |

アイコンの色を直接検査しているのは、Iconify がローカル SVG を「実質単色」と判定すると塗りを `currentColor` に置換するため（PR #74 で実測）。この置換が起きると多色ロゴがテーマの文字色に追従して壊れる。

## 検証内容

CI と同じ手順（クリーンインストール）で全工程を実行:

```
354 packages installed
Test Files 9 passed / Tests 86 passed (86)
astro check: 0 errors / 0 warnings
5 page(s) built / Complete!
スモークチェック成功: すべての項目が期待どおり
```

さらに **スモークチェック自体が回帰を検知できるか**を、成果物を意図的に壊して確認した（`SMOKE_DIST_DIR` で検査対象を差し替え）。

| 壊した内容 | 検知 |
|-|-|
| Skills の並び順を入れ替え | ✅ |
| Gallery の画像順を入れ替え | ✅ |
| Speaking の並び順を入れ替え | ✅ |
| Kiro の色を `currentColor` に置換 | ✅ |
| 記事 1 件のリンクを削除 | ✅ |
| ブログの並び順を入れ替え | ✅ |
| sitemap から 1 URL 削除 | ✅ |
| history ページを削除 | ✅ |
| `dist/catalog` を残す | ✅ |
| 無改変（誤検知しないか） | ✅ 成功のまま |

PR #74 で起きた回帰は、いずれもこのチェックで検知できる。

## 影響範囲

- 追加のみ。アプリケーションコードと `deploy.yml` は変更していない
- `package.json` に `check` / `smoke` スクリプトを追加（`bun run smoke` はビルド後に実行する）
- この PR 自体が新しい CI の最初の実行対象になる
