### PR TITLE
chore: TypeScript を 6.0.3 に更新し、7 系は追跡 Issue を立てて ignore する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore"
+    ignore:
+      # TypeScript 7 系（ネイティブコンパイラ）は astro check が依存する
+      # programmatic API を提供していないため型チェックが動作しない。
+      # Astro 側が対応したらこの ignore を削除する
+      # https://github.com/withastro/roadmap/discussions/1321
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
     # 関連パッケージはまとめて 1 PR にしてレビュー回数を減らす
     groups:
       astro:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "astro-icon": "^1.2.0",
         "daisyui": "^5.5.19",
         "tailwindcss": "^4.2.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
       "devDependencies": {
         "fast-check": "^4.5.3",
@@ -791,7 +791,7 @@
 
     "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "astro-icon": "^1.2.0",
     "daisyui": "^5.5.19",
     "tailwindcss": "^4.2.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "fast-check": "^4.5.3",


### PR DESCRIPTION
## 変更概要

Dependabot の PR #75（TypeScript 7.0.2）への対応。7 系は採用できないため 6 系に上げ、7 系の提案を止める。

## なぜ TypeScript 7 を採用できないのか

PR #75 のブランチを実際にインストールして検証したところ、`astro check` が終了コード 1 で失敗した。

```
The TypeScript module loaded (found 7.0.2) does not expose the programmatic API
that `astro check` relies on. TypeScript's native compiler (7.0 and later) does
not ship this API yet. Until it does, run `astro check` with a TypeScript version
that still provides it (6.x).
```

TypeScript 7 はネイティブコンパイラ（Go 実装）で、`astro check` が使う programmatic API がまだ提供されていない（[withastro/roadmap#1321](https://github.com/withastro/roadmap/discussions/1321) で追跡中）。`@astrojs/check` の peer 依存も `typescript: ^5.0.0 || ^6.0.0` で、6 系が上限になっている。

| 検証 | TS 5.9.3（現行） | TS 7.0.2（PR #75） | TS 6.0.3（本 PR） |
|-|-|-|-|
| `bun run test` | ✅ 86 pass | ✅ 86 pass | ✅ 86 pass |
| `bun run check` | ✅ 0 errors | ❌ **終了コード 1** | ✅ **0 errors** |
| `bun run build` | ✅ | ✅ | ✅ |

`build` は型チェックを行わないため TS 7 でも通ってしまう点に注意。CI で `astro check` を回していなければ気づかないまま壊れていた。

## 変更内容

1. **TypeScript を `^6.0.3` に更新** — 実測で `astro check` が 0 errors / 0 warnings で通る
2. **`dependabot.yml` に 7 系の ignore を追加** — Astro が対応するまで毎週 PR が来るのを防ぐ

   ```yaml
   ignore:
     - dependency-name: "typescript"
       versions: [">=7.0.0"]
   ```

   `@dependabot ignore this major version` コマンドでも同じことができるが、その設定は Dependabot 側の内部状態に保存されリポジトリには残らない。設定ファイルに書くことで「なぜ無視しているのか」「いつ解除できるのか」をコードとして残し、1 行削除で戻せるようにした。

   **ignore の唯一の弱点は「解除を忘れること」**なので、追跡用に #78 を立てた。Astro が TypeScript 7 に対応したら #78 の手順で ignore を外す。

3. **`ci.yml` の `actions/checkout` を v7 に揃える** — PR #76 が他のワークフローを v7 に更新するため、Dependabot の PR が重複しないようにする

## 検証内容

クリーンインストール（CI と同じ手順）で全工程を実行:

```
354 packages installed
Test Files 9 passed / Tests 86 passed (86)
astro check: 0 errors / 0 warnings（48 files）
5 page(s) built / Complete!
スモークチェック成功: すべての項目が期待どおり
bun audit: No vulnerabilities found
```

`dependabot.yml` は YAML として解釈できること、`ignore` が意図した構造になっていることを確認済み。

## 影響範囲

- TypeScript のメジャーアップグレード（5.9 → 6.0）だが、型エラー・テスト・ビルド・スモークすべて影響なし
- アプリケーションコードの変更はない
- この PR のマージ後、PR #75 は `@dependabot close` で閉じてよい状態になる

## 補足: PR #75 は security 起因ではない

念のため確認したが、#75 のラベルは `dependencies` / `javascript` のみで security 系は付いておらず、`bun audit` も `No vulnerabilities found` で TypeScript 5.9.3 に既知の脆弱性はない。本文中の "security" は互換性スコアバッジのドキュメントリンクという定型文だった。

つまり #75 は**純粋なバージョン追従**であり、緊急性はない。一方で TypeScript 7 は無視して良い更新ではなく（フルビルド 8〜12 倍）、あくまで Astro 側の対応を待つだけなので #78 で追跡する。

Refs #78
