### PR TITLE
feat: OSS 欄に自作リポジトリ permissions-for-kiro を追加

### DIFF
--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -64,6 +64,6 @@ public/
 - Hero: `col-span-8`、SNSリンク: `col-span-4`
 - CareerTimeline: `col-span-4`、Skills: `col-span-8`
 - Blog一覧: `col-span-12`（横スクロール、各カテゴリ最新 5 件 + 「全てを見る」ボタン）
-- Activity（OSS Contributions + Speaking）: `col-span-12`
+- Activity（Open Source + Speaking）: `col-span-12`
 
 モバイル: 全カード縦積み

--- a/doc/blueprint.md
+++ b/doc/blueprint.md
@@ -43,7 +43,7 @@ AWSに勤務するエンジニアの個人紹介サイト。主にKiroのブロ�
 | 経歴タイムライン | 最新 4 件を縦タイムラインで表示。「全てを見る」ボタンを常に表示し `/history` へ遷移 |
 | スキル | カテゴリ別技術スキル一覧 |
 | ブログ記事一覧 | 翻訳・執筆記事の OGP カード一覧。各カテゴリ最新 5 件を横スクロール表示し、末尾に「全てを見る」ボタンで `/history#blog` へ遷移 |
-| Activity | OSS コントリビューション一覧 + 登壇履歴（Speaking）一覧 |
+| Activity | Open Source 一覧（自作プロジェクト + 他リポジトリへのコントリビューション） + 登壇履歴（Speaking）一覧 |
 | SNSリンク | GitHub、LinkedIn、Qiita、Zenn |
 
 ### 4.2 ギャラリーページ (`/gallery`)
@@ -55,7 +55,7 @@ AWSに勤務するエンジニアの個人紹介サイト。主にKiroのブロ�
 ### 4.3 ヒストリーページ (`/history`)
 
 - 全経歴エントリーを縦タイムラインで表示
-- Activity（OSS Contributions + Speaking）セクションを表示
+- Activity（Open Source + Speaking）セクションを表示
 - ブログ全件リスト（`id="blog"`）を Activity の下に配置。PC 幅では 4 列グリッド、スマホでは横スクロール
 - エントリー数に関わらず常にヘッダーナビからアクセス可能
 - トップページの「全てを見る」ボタンは常に表示する
@@ -147,7 +147,7 @@ AWSに勤務するエンジニアの個人紹介サイト。主にKiroのブロ�
 │  Blog 記事一覧（OGPカード横スクロール）  │
 │  col-span-12                            │
 ├─────────────────────────────────────────┤
-│  Activity（OSS Contributions + Speaking）│
+│  Activity（Open Source + Speaking）     │
 │  col-span-12                            │
 └─────────────────────────────────────────┘
 ```
@@ -230,7 +230,7 @@ src/components/
 | `gallery` | `file`（JSON） | id, src, alt, width, height |
 | `skills` | `file`（JSON） | id, name, category, icon, url |
 | `career` | `file`（JSON） | id, organization, role, startDate, endDate（nullable）, description（nullable, optional）※表示時は startDate 降順（最新が上）|
-| `oss` | `file`（JSON） | id, repo, url, description |
+| `oss` | `file`（JSON） | id, order, repo, url, description ※表示時は order 昇順（小さい方が上）|
 | `speaking` | `file`（JSON） | id, title, event, date, url（nullable）, description（nullable, optional）|
 
 ### 7.3 ディレクトリ構成

--- a/src/components/organisms/ActivitySection.astro
+++ b/src/components/organisms/ActivitySection.astro
@@ -6,6 +6,9 @@ import SpeakingCard from '../molecules/SpeakingCard.astro';
 const allOss = await getCollection('oss');
 const allSpeaking = await getCollection('speaking');
 
+// order 昇順（小さい方が先）。getCollection() の返却順は保証されないため明示的に並べる
+const sortedOss = [...allOss].sort((a, b) => a.data.order - b.data.order);
+
 // date 降順（最新が先）。date は YYYY[-MM[-DD]] なので辞書順比較で時系列順になる
 const sortedSpeaking = [...allSpeaking].sort((a, b) => b.data.date.localeCompare(a.data.date));
 ---
@@ -17,11 +20,11 @@ const sortedSpeaking = [...allSpeaking].sort((a, b) => b.data.date.localeCompare
     Activity
   </h2>
 
-  <!-- OSS Contributions -->
+  <!-- Open Source -->
   <div class="flex flex-col gap-3">
-    <h3 class="text-sm md:text-base font-mono text-text-muted">OSS Contributions</h3>
+    <h3 class="text-sm md:text-base font-mono text-text-muted">Open Source</h3>
     <div class="flex flex-col gap-3">
-      {allOss.map((item) => (
+      {sortedOss.map((item) => (
         <OssItemSimple repo={item.data.repo} url={item.data.url} description={item.data.description} />
       ))}
     </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -59,11 +59,13 @@ const career = defineCollection({
   }),
 });
 
-// OSS コントリビューションコレクション
+// OSS コレクション（自作プロジェクト + 他リポジトリへのコントリビューション）
+// getCollection() の返却順は保証されないため、表示順は order で明示する
 const oss = defineCollection({
   loader: file('./src/data/oss/contributions.json'),
   schema: z.object({
     id: z.string(),
+    order: z.number().int().positive(),
     repo: z.string(),
     url: z.url(),
     description: z.string(),

--- a/src/data/blog/ogp-cache.json
+++ b/src/data/blog/ogp-cache.json
@@ -230,7 +230,13 @@
   "https://github.com/aws-samples/dify-self-hosted-on-aws": {
     "title": "GitHub - aws-samples/dify-self-hosted-on-aws: Self-host Dify on AWS",
     "description": "Self-host Dify on AWS. Contribute to aws-samples/dify-self-hosted-on-aws development by creating an account on GitHub.",
-    "ogpImage": "https://opengraph.githubassets.com/443e1d8c7b085e960f92dc78e52c3af01b2b9514cb20ab3fdf9affffb46355f4/aws-samples/dify-self-hosted-on-aws",
+    "ogpImage": "https://opengraph.githubassets.com/cd63c2d8b392503c92c502e0443dc3bdc6b5b0b70fd1acc5f194f212bb03911c/aws-samples/dify-self-hosted-on-aws",
+    "publishedAt": null
+  },
+  "https://github.com/yosse95ai/permissions-for-kiro": {
+    "title": "GitHub - yosse95ai/permissions-for-kiro",
+    "description": "Contribute to yosse95ai/permissions-for-kiro development by creating an account on GitHub.",
+    "ogpImage": "https://opengraph.githubassets.com/4f7e87111742cda24c22eb0ce9066709bc35981fb81630f6bfa976eca596d546/yosse95ai/permissions-for-kiro",
     "publishedAt": null
   }
 }

--- a/src/data/oss/contributions.json
+++ b/src/data/oss/contributions.json
@@ -1,6 +1,14 @@
 [
   {
+    "id": "permissions-for-kiro",
+    "order": 1,
+    "repo": "yosse95ai/permissions-for-kiro",
+    "url": "https://github.com/yosse95ai/permissions-for-kiro",
+    "description": "自作の Kiro 拡張機能。実際に効いている権限ルールをサイドバーにツリー表示し、定義行へジャンプできる。Open VSX で公開中。"
+  },
+  {
     "id": "dify-self-hosted-on-aws",
+    "order": 2,
     "repo": "aws-samples/dify-self-hosted-on-aws",
     "url": "https://github.com/aws-samples/dify-self-hosted-on-aws",
     "description": "AWS 上での Dify セルフホスト環境を実際に活用する中で発見した不具合を OSS にフィードバックし、バグ修正 PR をマージ済み。メンテナー。"


### PR DESCRIPTION
## 変更概要

サイトの Activity セクションに、自作 OSS の [`yosse95ai/permissions-for-kiro`](https://github.com/yosse95ai/permissions-for-kiro) を追加します。

あわせて以下 2 点を対応しました。

**`oss` コレクションへの `order` 追加**

これまで `ActivitySection.astro` は `getCollection('oss')` の結果をソートせずそのまま `map` していました。`content.config.ts` のコメントにもあるとおり `getCollection()` の返却順は保証されないため、エントリが 2 件になるこのタイミングで `gallery` / `skills` と同じ `order` 方式に揃えています。自作を先頭（`order: 1`）、dify を 2 番目（`order: 2`）としました。

**見出し `OSS Contributions` → `Open Source` へのリネーム**

自作プロジェクトは「他リポジトリへの貢献」ではないため、`Contributions` という語が実態とズレます。`Open Source` に変えることで自作・貢献の両方が自然に収まります。

なお、ロールの区別のために `role` フィールドやバッジ表示を追加する案は、当面自作 OSS を増やす予定がないため見送りました。説明文の冒頭にロールを置くことで区別しています（`line-clamp-3` で切られても残る位置）。

## 検証内容

```
bun run test   : 86 passed (9 files)
bun run check  : 0 errors, 0 warnings
bun run build  : 5 pages 成功
bun run smoke  : 全項目 OK
```

`check` の hint 1 件は `BaseLayout.astro` の既存のもので、本変更とは無関係です。

さらにビルド成果物 `dist/index.html` を直接検証しました。

| 項目 | 結果 |
|---|---|
| 見出しが `Open Source` になっている | OK |
| 旧見出し `OSS Contributions` の残留 | なし |
| 表示順（permissions-for-kiro が dify より先） | OK |
| OGP 画像が `opengraph.githubassets.com` で解決 | OK |
| 説明文の描画 | OK |

OGP キャッシュは `bun run ogp:refresh` で更新済み（40 件成功 / 0 失敗）。`github.com` は `ALLOWED_OGP_HOSTNAMES` に既に含まれているため、SSRF アローリストの変更は不要でした。

## 影響範囲

- **トップページ・ヒストリーページの Activity セクション** — OSS カードが 1 件から 2 件に増え、見出し文字列が変わります
- **`oss` コレクションのスキーマ** — `order` が必須フィールドになります。今後エントリを追加する際は `order` の指定が必要です
- **`catalog.astro`** — `OssItemSimple` にプロップスを直接渡すカタログのため、スキーマ変更の影響を受けません（未変更）
- ビルド・デプロイのフローに変更はありません

## 補足

`permissions-for-kiro` 側のリポジトリ説明（`description`）が未設定のため、GitHub が生成する OGP 画像のテキストが簡素になります。リポジトリ側に説明と topics を設定した後、あらためて `bun run ogp:refresh` を実行するとカードの見た目が改善します（本 PR の対象外）。
